### PR TITLE
replace torch.solve with torch.linalg.solve

### DIFF
--- a/geom/horo.py
+++ b/geom/horo.py
@@ -211,8 +211,8 @@ def horo_project_using_one_ideal(submanifold_ideals, x, custom_ideal_direction=N
     else:
         p = custom_ideal_direction
 
-    eucl_proj_coefs, _ = torch.solve(submanifold_ideals @ x.transpose(0, 1),
-                                     submanifold_ideals @ submanifold_ideals.transpose(0, 1))  # (sub_dim, batch_size)
+    eucl_proj_coefs = torch.linalg.solve(submanifold_ideals @ submanifold_ideals.transpose(0, 1),  # (sub_dim, batch_size)
+                                     submanifold_ideals @ x.transpose(0, 1))
     eucl_projs = eucl_proj_coefs.transpose(0, 1) @ submanifold_ideals  # (batch_size, dim)
 
     t = torch.sum((p - x) * (p - x), dim=-1) / (

--- a/geom/minkowski.py
+++ b/geom/minkowski.py
@@ -74,8 +74,8 @@ def orthogonal_projection(basis, x, bilinear_form=None):
     Warning: Will not work if the linear subspace spanned by basis is tangent to the light cone.
              (In that case, the orthogonal projection is not unique)
     """
-    coefs, _ = torch.solve(pairwise_bilinear_pairing(basis, x, bilinear_form),
-                           pairwise_bilinear_pairing(basis, basis, bilinear_form))
+    coefs = torch.linalg.solve(pairwise_bilinear_pairing(basis, basis, bilinear_form), 
+                               pairwise_bilinear_pairing(basis, x, bilinear_form))
 
     return coefs.transpose(-1, -2) @ basis
 


### PR DESCRIPTION
Running the code in this repo results in errors because this repo calls `torch.solve`, a function which is now deprecated. In this pull request, I replace `torch.solve` with the updated `torch.linalg.solve` function so that the code here can run smoothly.

A bit more detail: This repo calls `torch.solve` several times. However, since the [release](https://github.com/pytorch/pytorch/releases/tag/v1.9.0) of PyTorch 1.9, `torch.solve` has been replaced with `torch.linalg.solve`. [Note](https://github.com/pytorch/pytorch/pull/57741/files#r1245083530) that the order of the arguments is reversed in the new `torch.linalg.solve` function. For example, `torch.solve(b, A)` must become `torch.linalg.solve(A, b)`.

For more info, one can check  the order of the arguments in the old `torch.solve` [documentation](https://web.archive.org/web/20200805200546/https://pytorch.org/docs/stable/generated/torch.solve.html) compared to the new `torch.linalg.solve` [documentation](https://pytorch.org/docs/stable/generated/torch.linalg.solve.html).

Anyway, I updated this repo to use the newer `torch.linalg.solve`. I also made sure to swap the order of the arguments. Now everything should work. Cheers!